### PR TITLE
Update MaxTwo splitter tag and add build/push scripts

### DIFF
--- a/Algorithms/connectivity/sh/build.sh
+++ b/Algorithms/connectivity/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/connectivity:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building connectivity image: ${TAG}" 
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Algorithms/connectivity/sh/push.sh
+++ b/Algorithms/connectivity/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/connectivity:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing connectivity image: ${TAG}"
+docker push "${TAG}"

--- a/Algorithms/kilosort2_simplified/sh/build.sh
+++ b/Algorithms/kilosort2_simplified/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/kilosort2_simplified:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building kilosort2_simplified image: ${TAG}"
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Algorithms/kilosort2_simplified/sh/push.sh
+++ b/Algorithms/kilosort2_simplified/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/kilosort2_simplified:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing kilosort2_simplified image: ${TAG}"
+docker push "${TAG}"

--- a/Algorithms/visualization/sh/build.sh
+++ b/Algorithms/visualization/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/visualization:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building visualization image: ${TAG}"
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Algorithms/visualization/sh/push.sh
+++ b/Algorithms/visualization/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/visualization:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing visualization image: ${TAG}"
+docker push "${TAG}"

--- a/Services/MaxWell_Dashboard/sh/build.sh
+++ b/Services/MaxWell_Dashboard/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/maxwell_dashboard:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building maxwell_dashboard image: ${TAG}" 
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/MaxWell_Dashboard/sh/push.sh
+++ b/Services/MaxWell_Dashboard/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/maxwell_dashboard:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing maxwell_dashboard image: ${TAG}" 
+docker push "${TAG}" 

--- a/Services/Spike_Sorting_Listener/sh/build.sh
+++ b/Services/Spike_Sorting_Listener/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/spike_sorting_listener:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building spike_sorting_listener image: ${TAG}" 
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/Spike_Sorting_Listener/sh/push.sh
+++ b/Services/Spike_Sorting_Listener/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing spike_sorting_listener image: ${TAG}" 
+docker push "${TAG}" 

--- a/Services/Spike_Sorting_Listener/src/job_type_table.json
+++ b/Services/Spike_Sorting_Listener/src/job_type_table.json
@@ -5,5 +5,5 @@
     "surygeng/local_field_potential:v0.1": "Local Field Potential Subbands",
     "surygeng/qm_curation:v0.2": "Auto-Curation by Quality Metrics",
     "surygeng/visualization:v0.1": "Visualization",
-    "surygeng/maxtwo_splitter:v0.1": "MaxTwo Splitter"
+    "braingeneers/maxtwo_splitter:v0.3": "MaxTwo Splitter"
 }

--- a/Services/Spike_Sorting_Listener/src/mqtt_listener.py
+++ b/Services/Spike_Sorting_Listener/src/mqtt_listener.py
@@ -310,7 +310,7 @@ def get_splitter_config() -> dict:
         "memory_request": 48,  # Increased from 32 for better caching  
         "disk_request": 400,   # Keep same - needed for large 25GB+ files
         "GPU": 0,
-        "image": "surygeng/maxtwo_splitter:v0.2"  # Updated to optimized version
+        "image": "braingeneers/maxtwo_splitter:v0.3"  # Updated to optimized version
     }
     logging.info(f"Created optimized splitter config: {config}")
     return config

--- a/Services/job_scanner/sh/build.sh
+++ b/Services/job_scanner/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/job_scanner:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building job_scanner image: ${TAG}" 
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/job_scanner/sh/push.sh
+++ b/Services/job_scanner/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/job_scanner:v0.1, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing job_scanner image: ${TAG}" 
+docker push "${TAG}" 

--- a/Services/job_scanner/src/job_type_table.json
+++ b/Services/job_scanner/src/job_type_table.json
@@ -5,5 +5,5 @@
     "surygeng/local_field_potential:v0.1": "Local Field Potential Subbands",
     "surygeng/qm_curation:v0.2": "Auto-Curation by Quality Metrics",
     "surygeng/visualization:v0.1": "Visualization",
-    "surygeng/maxtwo_splitter:v0.1": "MaxTwo Splitter"
+    "braingeneers/maxtwo_splitter:v0.3": "MaxTwo Splitter"
 }

--- a/Services/maxtwo_splitter/sh/build.sh
+++ b/Services/maxtwo_splitter/sh/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_TAG="braingeneers/maxtwo_splitter:latest"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+echo "Building maxtwo_splitter image: ${TAG}" 
+docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/maxtwo_splitter/sh/push.sh
+++ b/Services/maxtwo_splitter/sh/push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/maxtwo_splitter:v0.3, before pushing." >&2
+  exit 1
+fi
+
+echo "Pushing maxtwo_splitter image: ${TAG}" 
+docker push "${TAG}" 


### PR DESCRIPTION
## Summary
- point the MaxTwo splitter configuration and job type tables to the braingeneers/maxtwo_splitter:v0.3 image
- add build and push helper scripts for the connectivity, visualization, kilosort2_simplified, maxtwo_splitter, spike_sorting_listener, job_scanner, and maxwell_dashboard Docker images

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f209c3208329be46f8fecac03c33)