### PR TITLE
Require explicit TAG for build scripts

### DIFF
--- a/Algorithms/connectivity/sh/build.sh
+++ b/Algorithms/connectivity/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/connectivity:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/connectivity:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building connectivity image: ${TAG}" 
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Algorithms/kilosort2_simplified/sh/build.sh
+++ b/Algorithms/kilosort2_simplified/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/kilosort2_simplified:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/kilosort2_simplified:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building kilosort2_simplified image: ${TAG}"
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Algorithms/visualization/sh/build.sh
+++ b/Algorithms/visualization/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/visualization:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/visualization:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building visualization image: ${TAG}"
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/MaxWell_Dashboard/sh/build.sh
+++ b/Services/MaxWell_Dashboard/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/maxwell_dashboard:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/maxwell_dashboard:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building maxwell_dashboard image: ${TAG}" 
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/Spike_Sorting_Listener/sh/build.sh
+++ b/Services/Spike_Sorting_Listener/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/spike_sorting_listener:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building spike_sorting_listener image: ${TAG}" 
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/job_scanner/sh/build.sh
+++ b/Services/job_scanner/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/job_scanner:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/job_scanner:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building job_scanner image: ${TAG}" 
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"

--- a/Services/maxtwo_splitter/sh/build.sh
+++ b/Services/maxtwo_splitter/sh/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/maxtwo_splitter:v0.1, before building." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DEFAULT_TAG="braingeneers/maxtwo_splitter:latest"
-TAG="${TAG:-${DEFAULT_TAG}}"
 
 echo "Building maxtwo_splitter image: ${TAG}" 
 docker build -t "${TAG}" -f "${PROJECT_ROOT}/docker/Dockerfile" "${PROJECT_ROOT}"


### PR DESCRIPTION
## Summary
- add TAG validation to all algorithm and service build scripts so users must set a tag explicitly
- remove default tag fallbacks to avoid unintended image names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69420d172cbc8329862a7668ebe72ad5)