### PR TITLE
Update splitter image references and listener build tag

### DIFF
--- a/Services/Spike_Sorting_Listener/docker/Dockerfile
+++ b/Services/Spike_Sorting_Listener/docker/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /app
 # run
 CMD ["python", "mqtt_listener.py"]
 
-# surygeng/spike_sorting_listener:v0.1
+# braingeneers/spike_sorting_listener:v0.2

--- a/Services/Spike_Sorting_Listener/sh/build.sh
+++ b/Services/Spike_Sorting_Listener/sh/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ -z "${TAG:-}" ]]; then
-  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.1, before building." >&2
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.2, before building." >&2
   exit 1
 fi
 

--- a/Services/Spike_Sorting_Listener/sh/push.sh
+++ b/Services/Spike_Sorting_Listener/sh/push.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ -z "${TAG:-}" ]]; then
-  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.1, before pushing." >&2
+  echo "Error: TAG environment variable is not set. Please set TAG, for example TAG=braingeneers/spike_sorting_listener:v0.2, before pushing." >&2
   exit 1
 fi
 

--- a/Services/Spike_Sorting_Listener/src/job_type_table.json
+++ b/Services/Spike_Sorting_Listener/src/job_type_table.json
@@ -1,4 +1,4 @@
- {
+{
     "surygeng/kilosort_docker:v0.2": "Kilosort2",
     "surygeng/connectivity:v0.1": "Functional Connectivity Analysis",
     "surygeng/ephys_pipeline:v0.1": "Ephys Pipeline (Kilosort2, Auto-Curation, Visualization)",

--- a/Services/Spike_Sorting_Listener/src/mqtt_listener.py
+++ b/Services/Spike_Sorting_Listener/src/mqtt_listener.py
@@ -33,6 +33,7 @@ TO_SLACK_TOPIC = "telemetry/slack/TOSLACK/ephys-data-pipeline"
 LOG_FILE_NAME = "listener.log"
 LOG_PATH = "s3://braingeneers/services/mqtt_job_listener/" + LOG_FILE_NAME
 DEFAULT_S3_BUCKET = "s3://braingeneers/ephys/"
+SPLITTER_IMAGE = "braingeneers/maxtwo_splitter:v0.3"
 
 # setup logging
 stream_handler = logging.StreamHandler()
@@ -307,10 +308,10 @@ def get_splitter_config() -> dict:
     config = {
         "args": "./start_splitter.sh",  # Container now has optimized version as default
         "cpu_request": 6,   # Increased from 4 for parallel processing
-        "memory_request": 48,  # Increased from 32 for better caching  
+        "memory_request": 48,  # Increased from 32 for better caching
         "disk_request": 400,   # Keep same - needed for large 25GB+ files
         "GPU": 0,
-        "image": "braingeneers/maxtwo_splitter:v0.3"  # Updated to optimized version
+        "image": SPLITTER_IMAGE  # Updated to optimized version
     }
     logging.info(f"Created optimized splitter config: {config}")
     return config

--- a/Services/job_scanner/src/job_type_table.json
+++ b/Services/job_scanner/src/job_type_table.json
@@ -1,4 +1,4 @@
- {
+{
     "surygeng/kilosort_docker:v0.2": "Kilosort2",
     "surygeng/connectivity:v0.1": "Functional Connectivity Analysis",
     "surygeng/ephys_pipeline:v0.1": "Ephys Pipeline (Kilosort2, Auto-Curation, Visualization)",


### PR DESCRIPTION
## Summary
- add a shared splitter image constant in the MQTT listener configuration
- clean up job type table files that list the MaxTwo splitter image
- update listener build/push helper scripts and Dockerfile comment to the v0.2 image tag example

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943053f1bc4832997006808e1625d75)