### PR TITLE
Fix S3 upload integrity errors

### DIFF
--- a/Services/maxtwo_splitter/src/start_splitter.sh
+++ b/Services/maxtwo_splitter/src/start_splitter.sh
@@ -135,8 +135,9 @@ aws configure set default.max_attempts 5              # Reduced from 10
 aws configure set default.cli_read_timeout 0
 aws configure set default.cli_connect_timeout 30      # Reduced from 60
 
-# Use fastest available checksum algorithm (or disable for speed)
-aws configure set default.s3.payload_signing_enabled false  # Disable signing for speed on internal network
+# Keep payload signing enabled for data integrity
+# (disabling caused XAmzContentSHA256Mismatch on multipart uploads)
+aws configure set default.s3.payload_signing_enabled true
 
 echo "=== OPTIMIZED SPLITTER STARTING ==="
 echo "Target: ${S3_URI}"

--- a/Services/maxtwo_splitter/src/start_splitter_optimized.sh
+++ b/Services/maxtwo_splitter/src/start_splitter_optimized.sh
@@ -58,8 +58,9 @@ aws configure set default.max_attempts 5              # Reduced from 10
 aws configure set default.cli_read_timeout 0
 aws configure set default.cli_connect_timeout 30      # Reduced from 60
 
-# Use fastest available checksum algorithm (or disable for speed)
-aws configure set default.s3.payload_signing_enabled false  # Disable signing for speed on internal network
+# Keep payload signing enabled for data integrity
+# (disabling caused XAmzContentSHA256Mismatch on multipart uploads)
+aws configure set default.s3.payload_signing_enabled true
 
 echo "=== OPTIMIZED SPLITTER STARTING ==="
 echo "Target: ${S3_URI}"


### PR DESCRIPTION
## Summary
- re-enable payload signing in both splitter launch scripts to avoid multipart SHA mismatches during uploads

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f6ebbff88329aac4bace5b203d4d)