### PR TITLE
Update MaxTwo splitter image to v0.31

### DIFF
--- a/Services/Spike_Sorting_Listener/src/mqtt_listener.py
+++ b/Services/Spike_Sorting_Listener/src/mqtt_listener.py
@@ -33,7 +33,7 @@ TO_SLACK_TOPIC = "telemetry/slack/TOSLACK/ephys-data-pipeline"
 LOG_FILE_NAME = "listener.log"
 LOG_PATH = "s3://braingeneers/services/mqtt_job_listener/" + LOG_FILE_NAME
 DEFAULT_S3_BUCKET = "s3://braingeneers/ephys/"
-SPLITTER_IMAGE = "braingeneers/maxtwo_splitter:v0.3"
+SPLITTER_IMAGE = "braingeneers/maxtwo_splitter:v0.31"
 
 # setup logging
 stream_handler = logging.StreamHandler()


### PR DESCRIPTION
## Summary
- update the MaxTwo splitter image reference to braingeneers/maxtwo_splitter:v0.31

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b49572d08329bca1f319ad595405)