### PR TITLE
Add CLI argument support for debug message sender

### DIFF
--- a/Services/maxtwo_splitter/sh/debug_message_sender.py
+++ b/Services/maxtwo_splitter/sh/debug_message_sender.py
@@ -6,6 +6,7 @@ import braingeneers.utils.s3wrangler as wr
 import os
 import time
 from pathlib import Path
+import sys
 
 TOPIC = "experiments/upload"
 INTER_BUCKET = "original/data/"
@@ -51,46 +52,47 @@ def create_message(uuid, exp_list, ow=False):
     return message
 
 
-if __name__ == '__main__':
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Send electrophysiology debug messages to the message broker."
+    )
+    parser.add_argument("--uuid", help="UUID of the experiment to process", required=True)
+    parser.add_argument("--inter-bucket", default=INTER_BUCKET,
+                        help="Intermediate bucket path segment (default: original/data/)")
+    parser.add_argument("--experiments", nargs="*", default=None,
+                        help="List of experiment filenames to process. If omitted, all are processed.")
+    parser.add_argument("--overwrite", type=lambda v: v.lower() in ["y", "yes", "true", "1"],
+                        default=False, help="Whether to overwrite results (y/n)")
+    return parser.parse_args()
+
+
+def validate_and_process(uuid, inter_bucket, experiment_selection, overwrite):
     default_bucket = "s3://braingeneers/ephys/"
     mb = messaging.MessageBroker(str(uuidgen.uuid4()))
 
     print("############### Welcome to Braingeneers Electrophysiology Data Pipeline ###############")
     print(f"Default bucket: {default_bucket}")
-    print(f"Default inter bucket: {INTER_BUCKET}")
+    print(f"Default inter bucket: {inter_bucket}")
 
-    change_inter_bucket = input("Do you want to change the inter bucket? y/n")
-    if change_inter_bucket == "y":
-        INTER_BUCKET = input("Please input the new inter bucket: ")
-        print(f"Inter bucket changed to {INTER_BUCKET}")
-    
     data_path = None
-    uuid = None
-    get_uuid = True
-    get_exp = True
-    get_overwrite = True
-    while get_uuid:
-        uuid = input("Please enter a UUID: ")
-        uuid = "".join(uuid.split())
-        print("Checking recordings in this UUID ... ")
-        if uuid.endswith("/"):
-            s3_path = os.path.join(default_bucket, uuid)
-        else:
-            uuid += "/"
-            s3_path = os.path.join(default_bucket, uuid)
-            print(wr.list_directories(s3_path))
-        if os.path.join(s3_path, INTER_BUCKET.split("/")[0]+"/") in wr.list_directories(s3_path):
-            data_path = os.path.join(s3_path, INTER_BUCKET)
-            # if wr.does_object_exist(os.path.join(s3_path, "metadata.json")):
-            #     metadata = ephys.load_metadata(uuid)
-            print(f"data path is {data_path}")
-            recs = wr.list_objects(data_path)
-            print(f"Found {len(recs)} recordings.")
-            for rec in recs:
-                print(rec)
-            get_uuid = False
-        else:
-            print("No available recording. Please input another UUID")
+    print("Checking recordings in this UUID ... ")
+    if uuid.endswith("/"):
+        s3_path = os.path.join(default_bucket, uuid)
+    else:
+        uuid += "/"
+        s3_path = os.path.join(default_bucket, uuid)
+        print(wr.list_directories(s3_path))
+    if os.path.join(s3_path, inter_bucket.split("/")[0]+"/") in wr.list_directories(s3_path):
+        data_path = os.path.join(s3_path, inter_bucket)
+        # if wr.does_object_exist(os.path.join(s3_path, "metadata.json")):
+        #     metadata = ephys.load_metadata(uuid)
+        print(f"data path is {data_path}")
+        recs = wr.list_objects(data_path)
+        print(f"Found {len(recs)} recordings.")
+        for rec in recs:
+            print(rec)
+    else:
+        raise ValueError("No available recording for the provided UUID.")
 
     exp_list = wr.list_objects(data_path)
     # More robust extraction of experiment names from S3 paths
@@ -99,36 +101,18 @@ if __name__ == '__main__':
         # Use Path to extract just the filename
         filename = Path(exp).name
         exp_name.append(filename)
-    
+
     print("Available experiment files:")
     for name in exp_name:
         print(f"  {name}")
-    # get experiment
-    experiment = None
-    while get_exp:
-        experiment = input("Enter experiment name \n"
-                        "(To run for all of the experiments in the provided UUID, press Enter) \n"
-                        "(To run on a selection of experiments, input the name one after another,"
-                        " separate them by space): ")
-        experiment = set(experiment.split(" "))
-        while "" in experiment:
-            experiment.remove("")
-        num = len(experiment)
-        if num > 0:
-            for i, exp in enumerate(experiment):
-                if not exp.endswith(".h5"):
-                    print("Please input the full name of the experiment, including the extension .h5 or .raw.h5")
-                    break
-                else:
-                    if exp not in exp_name:
-                        print(f"Experiment {exp} is not in the provided UUID")
-                        break
-                    else:
-                        if i == num - 1:
-                            get_exp = False
-        else:
-            get_exp = False
+    experiment = set(experiment_selection) if experiment_selection is not None else set()
 
+    if experiment_selection is not None:
+        for i, exp in enumerate(experiment):
+            if not exp.endswith(".h5"):
+                raise ValueError("Please input the full name of the experiment, including the extension .h5 or .raw.h5")
+            if exp not in exp_name:
+                raise ValueError(f"Experiment {exp} is not in the provided UUID")
 
     exp_exist = []
     if len(experiment) == 0:  # run for all experiments
@@ -138,16 +122,117 @@ if __name__ == '__main__':
         exp_exist = [os.path.join(data_path, exp) for exp in experiment]
         print(f"Getting read for the selected {len(exp_exist)} experiments...")
 
-    while get_overwrite:
-        ow_input = input("Overwrite result? y/n")
-        if ow_input == "y":
-            ow = True
-        else:
-            ow = False
-        print(f"User set overwrite to {ow}")
-        get_overwrite = False
+    ow = overwrite
+    print(f"User set overwrite to {ow}")
     metadata = create_message(uuid, exp_exist, ow)
     mb.publish_message(topic=TOPIC, message=metadata, confirm_receipt=True)
     time.sleep(0.1)
     print(f"Message sent to {TOPIC} for UUID {uuid} for processing {len(exp_exist)} experiments")
     print("############### Thank You ###############")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        default_bucket = "s3://braingeneers/ephys/"
+        mb = messaging.MessageBroker(str(uuidgen.uuid4()))
+
+        print("############### Welcome to Braingeneers Electrophysiology Data Pipeline ###############")
+        print(f"Default bucket: {default_bucket}")
+        print(f"Default inter bucket: {INTER_BUCKET}")
+
+        change_inter_bucket = input("Do you want to change the inter bucket? y/n")
+        if change_inter_bucket == "y":
+            INTER_BUCKET = input("Please input the new inter bucket: ")
+            print(f"Inter bucket changed to {INTER_BUCKET}")
+
+        data_path = None
+        uuid = None
+        get_uuid = True
+        get_exp = True
+        get_overwrite = True
+        while get_uuid:
+            uuid = input("Please enter a UUID: ")
+            uuid = "".join(uuid.split())
+            print("Checking recordings in this UUID ... ")
+            if uuid.endswith("/"):
+                s3_path = os.path.join(default_bucket, uuid)
+            else:
+                uuid += "/"
+                s3_path = os.path.join(default_bucket, uuid)
+                print(wr.list_directories(s3_path))
+            if os.path.join(s3_path, INTER_BUCKET.split("/")[0]+"/") in wr.list_directories(s3_path):
+                data_path = os.path.join(s3_path, INTER_BUCKET)
+                # if wr.does_object_exist(os.path.join(s3_path, "metadata.json")):
+                #     metadata = ephys.load_metadata(uuid)
+                print(f"data path is {data_path}")
+                recs = wr.list_objects(data_path)
+                print(f"Found {len(recs)} recordings.")
+                for rec in recs:
+                    print(rec)
+                get_uuid = False
+            else:
+                print("No available recording. Please input another UUID")
+
+        exp_list = wr.list_objects(data_path)
+        # More robust extraction of experiment names from S3 paths
+        exp_name = []
+        for exp in exp_list:
+            # Use Path to extract just the filename
+            filename = Path(exp).name
+            exp_name.append(filename)
+
+        print("Available experiment files:")
+        for name in exp_name:
+            print(f"  {name}")
+        # get experiment
+        experiment = None
+        while get_exp:
+            experiment = input("Enter experiment name \n"
+                            "(To run for all of the experiments in the provided UUID, press Enter) \n"
+                            "(To run on a selection of experiments, input the name one after another,"
+                            " separate them by space): ")
+            experiment = set(experiment.split(" "))
+            while "" in experiment:
+                experiment.remove("")
+            num = len(experiment)
+            if num > 0:
+                for i, exp in enumerate(experiment):
+                    if not exp.endswith(".h5"):
+                        print("Please input the full name of the experiment, including the extension .h5 or .raw.h5")
+                        break
+                    else:
+                        if exp not in exp_name:
+                            print(f"Experiment {exp} is not in the provided UUID")
+                            break
+                        else:
+                            if i == num - 1:
+                                get_exp = False
+            else:
+                get_exp = False
+
+
+        exp_exist = []
+        if len(experiment) == 0:  # run for all experiments
+            exp_exist = exp_list.copy()
+            print(f"Getting ready for all {len(exp_exist)} experiments...")
+        else:
+            exp_exist = [os.path.join(data_path, exp) for exp in experiment]
+            print(f"Getting read for the selected {len(exp_exist)} experiments...")
+
+        while get_overwrite:
+            ow_input = input("Overwrite result? y/n")
+            if ow_input == "y":
+                ow = True
+            else:
+                ow = False
+            print(f"User set overwrite to {ow}")
+            get_overwrite = False
+        metadata = create_message(uuid, exp_exist, ow)
+        mb.publish_message(topic=TOPIC, message=metadata, confirm_receipt=True)
+        time.sleep(0.1)
+        print(f"Message sent to {TOPIC} for UUID {uuid} for processing {len(exp_exist)} experiments")
+        print("############### Thank You ###############")
+    else:
+        args = parse_args()
+        INTER_BUCKET = args.inter_bucket
+        validate_and_process(args.uuid, INTER_BUCKET, args.experiments, args.overwrite)


### PR DESCRIPTION
## Summary
- add argparse support to provide UUID, inter-bucket, experiment list, and overwrite options via CLI
- retain existing interactive behavior when no arguments are supplied while sharing validation logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c8d21d508329bb0095e15b9fe67d)