### PR TITLE
Ensure GNU time installed in maxtwo splitter image

### DIFF
--- a/Services/maxtwo_splitter/docker/Dockerfile
+++ b/Services/maxtwo_splitter/docker/Dockerfile
@@ -2,22 +2,25 @@ FROM python:3.12
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DASH_DEBUG_MODE=False
 
-RUN apt-get update && apt-get install -y time \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    time \
     libxt-dev \
     curl \
     git \
     wget \
-    build-essential\
-    awscli\
-    zip\
-    glances\
-    pv\
-    bc\
-    coreutils\
-    gawk\
-    openssl\
-    psmisc\
-    && rm -rf /var/lib/apt/lists/*
+    build-essential \
+    awscli \
+    zip \
+    glances \
+    pv \
+    bc \
+    coreutils \
+    gawk \
+    openssl \
+    psmisc \
+    && rm -rf /var/lib/apt/lists/* && \
+    command -v /usr/bin/time
 
 RUN pip install "braingeneers[iot,analysis,data]"
 RUN pip install deprecated \ 


### PR DESCRIPTION
## Summary
- reorder the apt-get install step in the maxtwo splitter Dockerfile to install packages without recommendations
- explicitly verify /usr/bin/time exists during the image build

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c9a7e6108329a766e9b001191684)