### PR TITLE
Improve CLI help messages in debug_message_sender.py

### DIFF
--- a/Services/maxtwo_splitter/sh/debug_message_sender.py
+++ b/Services/maxtwo_splitter/sh/debug_message_sender.py
@@ -56,13 +56,34 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Send electrophysiology debug messages to the message broker."
     )
-    parser.add_argument("--uuid", help="UUID of the experiment to process", required=True)
-    parser.add_argument("--inter-bucket", default=INTER_BUCKET,
-                        help="Intermediate bucket path segment (default: original/data/)")
-    parser.add_argument("--experiments", nargs="*", default=None,
-                        help="List of experiment filenames to process. If omitted, all are processed.")
-    parser.add_argument("--overwrite", type=lambda v: v.lower() in ["y", "yes", "true", "1"],
-                        default=False, help="Whether to overwrite results (y/n)")
+    parser.add_argument(
+        "--uuid",
+        help="UUID of the experiment to process.",
+        required=True,
+    )
+    parser.add_argument(
+        "--inter-bucket",
+        default=INTER_BUCKET,
+        help=(
+            "Intermediate bucket path segment containing the recordings. "
+            f"Defaults to {INTER_BUCKET}."
+        ),
+    )
+    parser.add_argument(
+        "--experiments",
+        nargs="*",
+        default=None,
+        help=(
+            "Space-separated list of experiment filenames to process. "
+            "If omitted, all available experiments in the UUID are processed."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        type=lambda v: v.lower() in ["y", "yes", "true", "1"],
+        default=False,
+        help="Whether to overwrite existing results (y/n, yes/no, true/false).",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
### Motivation
- Make the command-line interface self-documenting by expanding help text for each option to reflect the script's interactive behavior.
- Clarify defaults and expected input formats so users can run the script non-interactively with the same semantics as the interactive prompts.
- Improve usability for automation and ad-hoc runs by clearly describing `--experiments` and `--overwrite` behaviors.

### Description
- Expanded `argparse` help for `--uuid` to clearly indicate it is the experiment identifier used by the script.
- Improved `--inter-bucket` help to mention the default path and its purpose, using the `INTER_BUCKET` constant in the message.
- Clarified `--experiments` help to state that it accepts a space-separated list of filenames and that omitting it runs all experiments in the UUID.
- Enhanced `--overwrite` help to accept multiple truthy values and explain accepted inputs, preserving the same type conversion used by the script.

### Testing
- No automated tests were run as part of this change.
- Changes were committed to the repository and the modified file is `Services/maxtwo_splitter/sh/debug_message_sender.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b29a9dc08329b35aab5ea0259dc9)