### PR TITLE
Simplify splitter upload phase to serial AWS CLI uploads

### DIFF
--- a/Services/maxtwo_splitter/src/start_splitter.sh
+++ b/Services/maxtwo_splitter/src/start_splitter.sh
@@ -263,7 +263,7 @@ process_time=$(($(date +%s) - process_start))
 echo "Processing completed in ${process_time}s"
 
 ###############################################################################
-# 6. PARALLEL upload optimization
+# 6. Upload phase (serial uploads)
 ###############################################################################
 echo "=== UPLOAD PHASE ==="
 upload_start=$(date +%s)
@@ -272,12 +272,7 @@ S3_SPLIT_PREFIX="${S3_URI/original\/data/original\/split}"
 S3_SPLIT_DIR="$(dirname "${S3_SPLIT_PREFIX}")"
 
 echo "Uploading split files from ${TARGET_DIR}/split_output to ${S3_SPLIT_DIR}/"
-echo "Using parallel uploads (${PARALLEL_UPLOADS} concurrent)"
-
-# Start background CPU activity during upload
-touch /tmp/io_in_progress
-keep_cpu_active "upload" &
-CPU_PID=$!
+echo "Using serial uploads (aws CLI handles multipart concurrency)"
 
 # Function to upload a single file with retry
 upload_file() {
@@ -292,10 +287,10 @@ upload_file() {
     echo "[$file_num] Starting upload: $base"
     
     while [ $retry_count -lt $MAX_RETRIES ]; do
+        echo "[$file_num] aws --endpoint \"${ENDPOINT}\" s3 cp \"${file}\" \"${dest}\""
         if aws --endpoint "${ENDPOINT}" s3 cp "${file}" "${dest}"; then
             success=1
             echo "[$file_num] SUCCESS: $base uploaded"
-            echo "success" > "/tmp/upload_${file_num}.status"
             return 0
         else
             retry_count=$((retry_count + 1))
@@ -308,7 +303,6 @@ upload_file() {
     done
     
     echo "[$file_num] FAILED: Upload failed permanently for $base"
-    echo "failed" > "/tmp/upload_${file_num}.status"
     return 1
 }
 
@@ -317,10 +311,10 @@ files_to_upload=("${TARGET_DIR}/split_output"/*.raw.h5)
 total_files=${#files_to_upload[@]}
 echo "Found ${total_files} files to upload"
 
-# Upload files in parallel batches
+# Upload files serially
 file_num=0
-upload_pids=()
-active_uploads=0
+success_count=0
+failed_count=0
 
 for file in "${files_to_upload[@]}"; do
     if [ ! -f "$file" ]; then
@@ -332,54 +326,8 @@ for file in "${files_to_upload[@]}"; do
     base=$(basename "${file}")
     dest="${S3_SPLIT_DIR}/${base}"
     
-    # Wait if we have too many active uploads
-    while [ $active_uploads -ge $PARALLEL_UPLOADS ]; do
-        sleep 1
-        # Check for completed uploads
-        for pid in "${upload_pids[@]}"; do
-            if ! kill -0 $pid 2>/dev/null; then
-                active_uploads=$((active_uploads - 1))
-                # Remove completed PID from array
-                upload_pids=(${upload_pids[@]/$pid})
-            fi
-        done
-    done
-    
-    # Start upload in background
-    upload_file "$file" "$dest" "$base" "$file_num" &
-    upload_pid=$!
-    upload_pids+=($upload_pid)
-    active_uploads=$((active_uploads + 1))
-    
-    echo "Started upload $file_num/$total_files: $base (PID: $upload_pid)"
-    
-    # Small delay to stagger starts
-    sleep 0.5
-done
-
-# Wait for all uploads to complete
-echo "Waiting for all uploads to complete..."
-for pid in "${upload_pids[@]}"; do
-    wait $pid
-done
-
-# Stop background CPU activity
-rm -f /tmp/io_in_progress
-wait $CPU_PID 2>/dev/null || true
-
-# Check upload results
-success_count=0
-failed_count=0
-
-for i in $(seq 1 $total_files); do
-    if [ -f "/tmp/upload_${i}.status" ]; then
-        status=$(cat "/tmp/upload_${i}.status")
-        if [ "$status" = "success" ]; then
-            success_count=$((success_count + 1))
-        else
-            failed_count=$((failed_count + 1))
-        fi
-        rm -f "/tmp/upload_${i}.status"
+    if upload_file "$file" "$dest" "$base" "$file_num"; then
+        success_count=$((success_count + 1))
     else
         failed_count=$((failed_count + 1))
     fi


### PR DESCRIPTION
### Motivation
- Reduce complexity in the splitter upload phase by removing custom parallel upload orchestration and background CPU activity.
- Rely on the AWS CLI's built-in multipart/multi-threading instead of spawning concurrent background uploads to avoid interference.
- Surface clearer, actionable error output for failed uploads by printing the exact `aws s3 cp` command being run.
- Mitigate multipart integrity errors (e.g. `XAmzContentSHA256Mismatch`) and make debugging simpler by performing uploads serially with retries.

### Description
- Replaced the parallel background upload logic in `Services/maxtwo_splitter/src/start_splitter.sh` with a simple serial upload loop. 
- Removed `keep_cpu_active` background activity, PID bookkeeping, and temporary `/tmp/upload_*.status` files used for parallel coordination.
- Added an explicit `echo` of the `aws --endpoint "${ENDPOINT}" s3 cp "${file}" "${dest}"` command before each upload and retained retry logic for each file.
- Track `success_count` and `failed_count` inline during the serial loop and report results in the existing performance summary.

### Testing
- No automated tests or CI jobs were executed as part of this change; functional validation is expected via pipeline runs or CI after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ccf9ff748329950631b7a9a78485)