### PR TITLE
Extract NRP memory allocation into helper and clean up splitter script

### DIFF
--- a/Services/maxtwo_splitter/src/nrp_memory_utilization.py
+++ b/Services/maxtwo_splitter/src/nrp_memory_utilization.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Allocate and lightly exercise memory to meet NRP utilization targets."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import numpy as np
+
+MEMORY_FLAG = Path("/tmp/memory_allocated")
+
+def allocate_arrays() -> list[np.ndarray]:
+    arrays: list[np.ndarray] = []
+    size_elements = int(2.0 * 1024 * 1024 * 1024 / 8)  # 2GB in float64 elements
+
+    for i in range(4):
+        arr = np.random.random(size=size_elements).astype(np.float64)
+        arrays.append(arr)
+
+        _ = np.mean(arr[::10000])
+        print(f"SAFE Array {i + 1}: {arr.nbytes / 1024 / 1024 / 1024:.1f}GB allocated")
+        time.sleep(1)
+
+    return arrays
+
+
+def run_cycles(arrays: list[np.ndarray]) -> None:
+    for cycle in range(3):
+        for arr in arrays:
+            _ = np.sum(arr[::50000])
+        time.sleep(5)
+        print(f"SAFE memory cycle {cycle + 1}/3 complete")
+
+
+def main() -> None:
+    arrays: list[np.ndarray] | None = None
+    try:
+        arrays = allocate_arrays()
+        MEMORY_FLAG.write_text("allocated")
+        run_cycles(arrays)
+        print("SAFE memory allocation cycle complete")
+    except Exception as exc:  # noqa: BLE001 - best-effort logging
+        print(f"SAFE memory allocation error: {exc}")
+    finally:
+        arrays = None
+
+
+if __name__ == "__main__":
+    main()

--- a/Services/maxtwo_splitter/src/start_splitter.sh
+++ b/Services/maxtwo_splitter/src/start_splitter.sh
@@ -9,6 +9,7 @@
 
 set -euo pipefail
 echo "Running start_splitter.sh v0.37"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ###############################################################################
 # 0. Arguments and optimized retry configuration
@@ -48,51 +49,7 @@ keep_cpu_active() {
             # SAFE memory utilization - only allocate once per cycle
             if [ ! -f "/tmp/memory_allocated" ]; then
                 echo "Allocating SAFE memory for NRP compliance: target 8-10GB of 48GB"
-                python3 -c "
-import time
-import numpy as np
-import gc
-import os
-
-try:
-    # SAFE allocation: only 8-10GB total (well under 48GB limit)
-    arrays = []
-    
-    # Create 4 arrays totaling ~8GB (safe for 48GB limit)
-    for i in range(4):
-        # Each array ~2GB (4 * 2GB = 8GB total)
-        size_elements = int(2.0 * 1024 * 1024 * 1024 / 8)  # 2GB in float64 elements
-        arr = np.random.random(size=size_elements).astype(np.float64)
-        arrays.append(arr)
-        
-        # Do computation to ensure allocation
-        mean_val = np.mean(arr[::10000])  # Sample for efficiency
-        print(f'SAFE Array {i+1}: {arr.nbytes/1024/1024/1024:.1f}GB allocated')
-        time.sleep(1)
-    
-    # Mark memory as allocated
-    with open('/tmp/memory_allocated', 'w') as f:
-        f.write('allocated')
-    
-    # Light computation cycle (reduced frequency)
-    for cycle in range(3):  # Reduced cycles
-        for i, arr in enumerate(arrays):
-            _ = np.sum(arr[::50000])  # Light computation
-        time.sleep(5)
-        print(f'SAFE memory cycle {cycle+1}/3 complete')
-    
-    print('SAFE memory allocation cycle complete')
-    
-except Exception as e:
-    print(f'SAFE memory allocation error: {e}')
-finally:
-    # Always clean up
-    try:
-        del arrays
-        gc.collect()
-    except:
-        pass
-" 2>/dev/null &
+                python3 "${SCRIPT_DIR}/nrp_memory_utilization.py" 2>/dev/null &
             fi
             
             # Wait before next cycle
@@ -113,9 +70,6 @@ finally:
     # Clean up memory allocation flag
     rm -f /tmp/memory_allocated 2>/dev/null || true
     
-    # Force garbage collection
-    python3 -c "import gc; gc.collect()" 2>/dev/null || true
-    killall -9 dd gzip find openssl python3 2>/dev/null || true
     echo "Background resource utilization stopped for ${operation_name}"
 }
 


### PR DESCRIPTION
### Motivation
- The embedded multiline Python in `start_splitter.sh` is hard to read and maintain, so it should be extracted into a separate helper file.
- Remove extraneous/no-op cleanup commands that have little to no effect to simplify the script.
- Make it easier to locate and reuse the NRP memory allocation logic from other scripts by placing it in its own module.

### Description
- Add a new helper `nrp_memory_utilization.py` that implements the SAFE memory allocation and light-compute cycles previously inlined in `start_splitter.sh`.
- Add `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` to `start_splitter.sh` so the script can reliably call the helper next to it.
- Replace the inline `python3 -c "..."` allocation block with a call to `python3 "${SCRIPT_DIR}/nrp_memory_utilization.py"` running in background.
- Remove the redundant `python3 -c "import gc; gc.collect()"` and the aggressive `killall -9 dd gzip find openssl python3` cleanup lines that were effectively no-ops or overly aggressive.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ea5229608329964d3ca8248d78fc)