### PR TITLE
Clarify Quick Start dashboard access and restart steps

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -251,9 +251,8 @@ aws s3 ls --endpoint-url=https://your-s3-endpoint s3://bucket-name/ephys/
 You should see a list of UUIDs (experiment folders).
 
 ### Test 2: Test Dashboard Connection
-TODO: the dashboard setting seems incorrect. Double check it. the browser address should not be localhost.  
-1. Start the dashboard: `docker-compose up`
-2. Open browser: `http://localhost:8050`
+1. Start the dashboard: `docker-compose up -d`
+2. Open browser: `http://localhost:8050` (or `http://<server-ip>:8050` if running remotely)
 3. Check if UUIDs appear in the dropdown
 4. If you see UUIDs, your configuration is correct!
 
@@ -285,11 +284,8 @@ vim .env
 ```
 
 After editing, restart the services:
-
-TODO: Correct the following commands
 ```bash
-docker-compose rm -sf service 
-docker-compose up -d service 
+docker-compose up -d
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
### Motivation
- Remove ambiguous TODOs in the Quick Start so users know how to start the dashboard and restart services after changing configuration.
- Clarify the difference between local and remote access to the dashboard so operators can access `:8050` when running remotely.
- Make the documented restart workflow concrete and consistent with the provided `docker-compose.yml` setup.

### Description
- Update `QUICK_START.md` Test 2 to use `docker-compose up -d` and add a note to use `http://<server-ip>:8050` for remote servers.
- Replace the placeholder restart sequence with the concrete command `docker-compose up -d` after editing `.env`.
- Commit includes the single documentation file change: `QUICK_START.md`.

### Testing
- This is a documentation-only change and no automated tests were run.
- The change was committed locally and the file diff was validated to contain the intended edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614b1e7fc08329ab70ffa1f9128638)